### PR TITLE
[Minyoung] 계정관리 페이지('/Mypage'), 대시보드 수정 페이지('/Edit') 페이지 수정

### DIFF
--- a/src/constants/constant.ts
+++ b/src/constants/constant.ts
@@ -54,4 +54,4 @@ export const FOOTER_SOCIAL_LIST = [
   },
 ];
 
-export const DASHBOARD_COLOR_LIST = ['#7ac555', '#760dde', '#ffa500', '#76a5ea', '#e876ea'];
+export const DASHBOARD_COLOR_LIST = ['#7AC555', '#760DDE', '#FFA500', '#76A5EA', '#E876EA'];

--- a/src/pages/Dashboard/[dashboardId]/Edit/index.tsx
+++ b/src/pages/Dashboard/[dashboardId]/Edit/index.tsx
@@ -49,8 +49,11 @@ const Edit = () => {
   };
 
   useEffect(() => {
+    if (!dashboardId) {
+      return;
+    }
     loadDashboardInfo();
-  }, []);
+  }, [dashboardId]);
 
   // 대시보드 수정
   const handleChangeTitleAndColor = async () => {
@@ -96,8 +99,11 @@ const Edit = () => {
   };
 
   useEffect(() => {
+    if (!dashboardId) {
+      return;
+    }
     loadMemberList(currentPage);
-  }, [currentPage]);
+  }, [dashboardId, currentPage]);
 
   // 대시보드 멤버 삭제
   const handleMemberDelete = async (memberId: number) => {
@@ -127,8 +133,11 @@ const Edit = () => {
   };
 
   useEffect(() => {
+    if (!dashboardId) {
+      return;
+    }
     loadInvitationList(invitationCurrentPage);
-  }, [invitationCurrentPage, isInviteModalOpen]);
+  }, [dashboardId, invitationCurrentPage, isInviteModalOpen]);
 
   // 초대 삭제
   const handleinvitationDelete = async (invitationId: number) => {

--- a/src/pages/Mypage/Mypage.module.scss
+++ b/src/pages/Mypage/Mypage.module.scss
@@ -13,37 +13,38 @@
 }
 
 .mypageContent {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
   padding: 2rem;
   background-color: $gray_FA;
 }
 
-.backBtn {
-  @include text-m(500);
-
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 2.5rem;
-  color: $black_33;
-  font-style: normal;
-  gap: 0.6rem;
-  line-height: normal;
-}
-
 .mypageSection {
-  width: 62rem;
+  max-width: 62rem;
   flex-shrink: 0;
   padding: 3.2rem 2.8rem 2.8rem;
   border-radius: 8px;
   margin-bottom: 1.2rem;
   background: $white_FF;
+
+  @include media(tablet) {
+    width: 100%;
+  }
 }
 
 .profileContent {
   @extend %contentStyle;
 
+  width: 100%;
   align-items: center;
   gap: 1rem;
+
+  @include media(mobile) {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2.4rem;
+  }
 }
 
 .imageUpload {
@@ -55,10 +56,16 @@
   justify-content: center;
   border-radius: 6px;
   background: #f5f5f5;
+
+  @include media(mobile) {
+    width: 150px;
+    height: 150px;
+  }
 }
 
 .profileInputBox {
   display: flex;
+  width: 100%;
   flex-direction: column;
   gap: 2rem;
 }
@@ -80,7 +87,11 @@
 .profileInput {
   @extend %inputStyle;
 
-  width: 36.6rem;
+  max-width: 36.6rem;
+
+  @include media(tablet) {
+    width: 100%;
+  }
 
   &:disabled {
     @include text-m(400);
@@ -115,7 +126,11 @@
 .passwordChangeInput {
   @extend %inputStyle;
 
-  width: 56.4rem;
+  max-width: 56.4rem;
+
+  @include media(tablet) {
+    width: 100%;
+  }
 
   .passwordChangeInput::placeholder {
     @include text-m(400);
@@ -133,10 +148,21 @@
   flex-shrink: 0;
   align-items: center;
   justify-content: center;
+
+  @include media(mobile) {
+    width: 150px;
+    height: 150px;
+  }
 }
 
 .imagePreview {
   object-fit: cover;
+}
+
+.addIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .imageInputButton {
@@ -150,6 +176,11 @@
   background: #f5f5f5;
   cursor: pointer;
   user-select: none;
+
+  @include media(mobile) {
+    width: 150px;
+    height: 150px;
+  }
 }
 
 .inputErrorMessage {

--- a/src/pages/Mypage/index.tsx
+++ b/src/pages/Mypage/index.tsx
@@ -183,23 +183,27 @@ const Mypage: NextPageWithLayout = () => {
         </div>
       )}
       <div className={styles.mypageContent}>
-        <button className={styles.backBtn} onClick={() => router.back()}>
+        {/* <button className={styles.backBtn} onClick={() => router.back()}>
           <Image src={backIcon} alt="돌아가기" />
           <p>돌아가기</p>
-        </button>
+        </button> */}
         <section className={styles.mypageSection}>
           <h3 className={styles.title}>프로필</h3>
           <div className={styles.profileContent}>
             <div className={styles.imageUpload}>
               <label htmlFor="imageInputField" className={styles.imageInputButton}>
-                <Image
-                  className={styles.imagePreview}
-                  src={profileImage ? profileImage : addIcon}
-                  layout="responsive"
-                  width={30}
-                  height={30}
-                  alt="추가한 이미지"
-                />
+                {profileImage ? (
+                  <Image
+                    className={styles.imagePreview}
+                    src={profileImage}
+                    layout="responsive"
+                    width={30}
+                    height={30}
+                    alt="추가한 이미지"
+                  />
+                ) : (
+                  <Image className={styles.imagePreview} src={addIcon} width={30} height={30} alt="추가한 이미지" />
+                )}
               </label>
               <input
                 id="imageInputField"

--- a/src/pages/Mypage/index.tsx
+++ b/src/pages/Mypage/index.tsx
@@ -1,35 +1,16 @@
 import { useEffect, useState, ChangeEvent, ReactElement } from 'react';
 import Image from 'next/image';
-import { useRouter } from 'next/router';
-import httpClient from '@/src/apis/httpClient';
-import SingleButtonModal from '@/src/components/Modal/SingleButtonModal';
-import TaskButton from '@/src/components/common/Button/TaskButton';
-import addIcon from '@/src/assets/icons/addIcon.svg';
-import backIcon from '@/src/assets/icons/leftArrowIcon.svg';
-import styles from './Mypage.module.scss';
 import { NextPageWithLayout } from '../_app';
 import HeaderSidebarLayout from '@/src/components/common/Layout/HeaderSidebarLayout';
-
-interface UserInfo {
-  id: number;
-  email: string;
-  nickname: string;
-  profileImageUrl: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-const initialUserInfo: UserInfo = {
-  id: 0,
-  email: '',
-  nickname: '',
-  profileImageUrl: '',
-  createdAt: '',
-  updatedAt: '',
-};
+import SingleButtonModal from '@/src/components/Modal/SingleButtonModal';
+import TaskButton from '@/src/components/common/Button/TaskButton';
+import httpClient from '@/src/apis/httpClient';
+import { initialUserInfo } from '@/src/types/mypageResponse';
+import addIcon from '@/src/assets/icons/addIcon.svg';
+import styles from './Mypage.module.scss';
 
 const Mypage: NextPageWithLayout = () => {
-  const [userInfo, setUserInfo] = useState<UserInfo>(initialUserInfo);
+  const [userInfo, setUserInfo] = useState(initialUserInfo);
   const [nickname, setNickname] = useState<string>('');
   const [profileImage, setProfileImage] = useState<string>('');
   const [isUpdateTrigger, setIsUpdateTrigger] = useState<boolean>(false);
@@ -41,8 +22,6 @@ const Mypage: NextPageWithLayout = () => {
   const [isSaveButtonEnabled, setIsSaveButtonEnabled] = useState<boolean>(false);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [modalMessage, setModalMessage] = useState<string>('');
-
-  const router = useRouter();
 
   // userInfo 가져오기
   async function getUserInfo() {
@@ -183,10 +162,6 @@ const Mypage: NextPageWithLayout = () => {
         </div>
       )}
       <div className={styles.mypageContent}>
-        {/* <button className={styles.backBtn} onClick={() => router.back()}>
-          <Image src={backIcon} alt="돌아가기" />
-          <p>돌아가기</p>
-        </button> */}
         <section className={styles.mypageSection}>
           <h3 className={styles.title}>프로필</h3>
           <div className={styles.profileContent}>
@@ -202,7 +177,7 @@ const Mypage: NextPageWithLayout = () => {
                     alt="추가한 이미지"
                   />
                 ) : (
-                  <Image className={styles.imagePreview} src={addIcon} width={30} height={30} alt="추가한 이미지" />
+                  <Image className={styles.addIcon} src={addIcon} width={30} height={30} alt="추가한 이미지" />
                 )}
               </label>
               <input

--- a/src/types/mypageResponse.ts
+++ b/src/types/mypageResponse.ts
@@ -1,0 +1,17 @@
+export interface UserInfo {
+  id: number;
+  email: string;
+  nickname: string;
+  profileImageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const initialUserInfo: UserInfo = {
+  id: 0,
+  email: '',
+  nickname: '',
+  profileImageUrl: '',
+  createdAt: '',
+  updatedAt: '',
+};


### PR DESCRIPTION
## 변경 사항
- 계정관리 페이지('/Mypage') -> profileImage 없을 시 addIcon 크기 수정
- 계정관리 페이지('/Mypage') -> 반응형 구현
- 대시보드 수정 페이지('/Edit') 페이지 -> router.query undefined 에러 수정

## To. reviewers
- 반응형은 사이드바 반응형 완성되면 다시 한 번 더 확인할게오 !
- router.query undefined 에러 수정한 부분 너무 맘에 안 들지만 `router.isReady` 메서드 사용 실패로 조금 더 고민해보겠습니다 에러 해결은 했어요 !

## 이슈 번호
- #53 

## (테스트 결과)
- 계정관리 페이지('/Mypage') profileImage 없을 시 addIcon
<img width="638" alt="스크린샷 2024-04-29 오후 5 08 08" src="https://github.com/thgus5335/DoThisDoThat/assets/155047307/ded31c47-45b7-4128-b821-c75e98e6a7a7">

---

- 계정관리 페이지('/Mypage') 반응형
## pc
<img width="599" alt="스크린샷 2024-04-29 오후 2 54 31" src="https://github.com/thgus5335/DoThisDoThat/assets/155047307/97fbc5ce-8a88-4f9f-817a-4df2804976e0">

## tablet
<img width="535" alt="스크린샷 2024-04-29 오후 2 43 51" src="https://github.com/thgus5335/DoThisDoThat/assets/155047307/85bc1a9f-d684-41bb-83ac-746960fadd05">

## mobile
<img width="383" alt="스크린샷 2024-04-29 오후 2 53 22" src="https://github.com/thgus5335/DoThisDoThat/assets/155047307/78f98fea-e6a5-4929-b647-2c78dcee59ab">

