### PR TITLE
[Minyoung] 대시보드 수정 페이지('/Edit') 프로필 이미지 없을 때 처리 추가

### DIFF
--- a/src/pages/Dashboard/[dashboardId]/Edit/Edit.module.scss
+++ b/src/pages/Dashboard/[dashboardId]/Edit/Edit.module.scss
@@ -150,10 +150,16 @@
 }
 
 .profileImg {
+  @include text-m(600);
+
+  position: relative;
+  display: flex;
   width: 3.8rem;
   height: 3.8rem;
-  border-radius: 9999px;
-  background-color: #9dd7ed;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  color: $white_FF;
 }
 
 .members {

--- a/src/pages/Dashboard/[dashboardId]/Edit/Edit.module.scss
+++ b/src/pages/Dashboard/[dashboardId]/Edit/Edit.module.scss
@@ -1,19 +1,7 @@
 .editpageLayout {
+  width: 100%;
   padding: 2.5rem;
   background: #fafafa;
-}
-
-.backBtn {
-  @include text-m(500);
-
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 2.5rem;
-  color: $black_33;
-  font-style: normal;
-  gap: 0.6rem;
-  line-height: normal;
 }
 
 .editpageSection {

--- a/src/pages/Dashboard/[dashboardId]/Edit/index.tsx
+++ b/src/pages/Dashboard/[dashboardId]/Edit/index.tsx
@@ -16,6 +16,7 @@ import styles from './Edit.module.scss';
 import DoubleButtonModal from '@/src/components/Modal/DoubleButtonModal';
 import NewInviteModal from '@/src/components/Modal/ModalType/NewInviteModal/NewInviteModal';
 import HeaderSidebarLayout from '@/src/components/common/Layout/HeaderSidebarLayout';
+import { getRandomcolorForPrefix } from '@/src/utils/makeRandomColor';
 
 const Edit = () => {
   const router = useRouter();
@@ -229,11 +230,11 @@ const Edit = () => {
             </div>
             <p className={styles.infoCategory}>이름</p>
             <div className={styles.members}>
-              {memberList.map(member => (
+              {memberList.map((member, index) => (
                 <div key={member.id} className={styles.memberInfo}>
                   <div className={styles.imgAndNickname}>
                     <div className={styles.profileImg}>
-                      {member.profileImageUrl && (
+                      {member.profileImageUrl ? (
                         <Image
                           className={styles.profileImg}
                           src={member.profileImageUrl}
@@ -241,6 +242,16 @@ const Edit = () => {
                           width={38}
                           height={38}
                         />
+                      ) : (
+                        <div
+                          className={styles.profileImg}
+                          style={{
+                            left: `${index * -1}rem`,
+                            backgroundColor: getRandomcolorForPrefix(member.nickname.substring(0, 1)).color,
+                          }}
+                          key={member.id}>
+                          {member.nickname.substring(0, 1)}
+                        </div>
                       )}
                     </div>
                     <p className={styles.nickname}>{member.nickname}</p>

--- a/src/pages/Dashboard/[dashboardId]/Edit/index.tsx
+++ b/src/pages/Dashboard/[dashboardId]/Edit/index.tsx
@@ -29,6 +29,7 @@ const Edit = () => {
   const [isButtonEnabled, setIsButtonEnabled] = useState<boolean>(false);
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState<boolean>(false);
   const [isInviteModalOpen, setIsInviteModalOpen] = useState<boolean>(false);
+  // const [isDeleteDashboardModalOpen, setIsDeleteDashboardModalOpen] = useState<boolean>(false);
   const [memberList, setMemberList] = useState<MemberList[]>([]);
   const [invitationList, setInvitationList] = useState<InvitationList[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
@@ -166,6 +167,11 @@ const Edit = () => {
           <NewInviteModal dashboardId={dashboardId} onClose={() => setIsInviteModalOpen(false)} />
         </DoubleButtonModal>
       )}
+      {/* {isDeleteDashboardModalOpen && (
+        <SingleButtonModal isOpen onClick={handleDashboardDelete} onClose={() => setIsDeleteDashboardModalOpen(false)}>
+          " {dashboardInfo.title} " 대시보드를 삭제하겠습니까 ?
+        </SingleButtonModal>
+      )} */}
       <HeaderSidebarLayout dashboardId={dashboardId}>
         <div className={styles.editpageLayout}>
           <section className={styles.editpageSection}>


### PR DESCRIPTION
## 변경 사항
- 대시보드 수정 페이지('/Edit') 프로필 이미지 없을 때 처리 추가 
- 구성원 삭제, 초대 취소, 대시보드 삭제하기 -> 추후에 모달 연결할 예정 ! 

## 이슈 번호
- #53 

## (테스트 결과)
<img width="611" alt="스크린샷 2024-04-30 오전 1 39 18" src="https://github.com/thgus5335/DoThisDoThat/assets/155047307/e9629f1b-fedc-42ce-8c54-1121a67819d2">

