### PR TITLE
[Minyoung] 대시보드 수정 페이지(/Edit), 계정관리 페이지(/Mypage) 반응형 구현 및 수정, InputComponent 수정

### DIFF
--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -55,9 +55,9 @@ export default function Input<T extends string>({
       {type === 'password' && (
         <div onClick={togglePasswordVisibility} className={styles.toggleButton}>
           {showPassword ? (
-            <FontAwesomeIcon icon={faEyeSlash} className={styles.icon} />
-          ) : (
             <FontAwesomeIcon icon={faEye} className={styles.icon} />
+          ) : (
+            <FontAwesomeIcon icon={faEyeSlash} className={styles.icon} />
           )}
         </div>
       )}

--- a/src/pages/Dashboard/[dashboardId]/Edit/Edit.module.scss
+++ b/src/pages/Dashboard/[dashboardId]/Edit/Edit.module.scss
@@ -5,12 +5,16 @@
 }
 
 .editpageSection {
-  width: 62rem;
+  max-width: 62rem;
   flex-shrink: 0;
   padding: 3.5rem 3rem;
   border-radius: 8px;
   margin-bottom: 1.2rem;
   background: $white_FF;
+
+  @include media(tablet) {
+    width: 100%;
+  }
 }
 
 .dashboardNameAndColor {
@@ -58,6 +62,12 @@
   }
 }
 
+@include media(mobile) {
+  .mobileOnly {
+    display: none;
+  }
+}
+
 .nameChangeInputBox {
   display: flex;
   flex-direction: column;
@@ -76,7 +86,7 @@
 .dashboardNameInput {
   @include text-m(400);
 
-  width: 56.4rem;
+  max-width: 56.4rem;
   height: 4.8rem;
   flex-shrink: 0;
   padding: 1.5rem;
@@ -86,6 +96,10 @@
   color: $black_33;
   font-style: normal;
   line-height: normal;
+
+  @include media(tablet) {
+    width: 100%;
+  }
 }
 
 .taskBtn {
@@ -103,6 +117,10 @@
   flex-shrink: 0;
   align-items: center;
   justify-content: space-between;
+
+  @include media(mobile) {
+    align-items: flex-start;
+  }
 }
 
 .sectionTitle {
@@ -212,6 +230,11 @@
   display: flex;
   align-items: center;
   gap: 1.6rem;
+
+  @include media(mobile) {
+    flex-direction: column;
+    align-items: flex-end;
+  }
 }
 
 .noInvitations {

--- a/src/pages/Dashboard/[dashboardId]/Edit/index.tsx
+++ b/src/pages/Dashboard/[dashboardId]/Edit/index.tsx
@@ -181,7 +181,7 @@ const Edit = () => {
                 {DASHBOARD_COLOR_LIST.map(color => (
                   <div key={color} className={styles.colorSelectContainer}>
                     <input
-                      className={styles.colorSelect}
+                      className={`${styles.colorSelect} ${selectedColor !== color && styles.mobileOnly}`}
                       type="radio"
                       value={color}
                       checked={selectedColor === color}
@@ -252,7 +252,6 @@ const Edit = () => {
                         <div
                           className={styles.profileImg}
                           style={{
-                            left: `${index * -1}rem`,
                             backgroundColor: getRandomcolorForPrefix(member.nickname.substring(0, 1)).color,
                           }}
                           key={member.id}>

--- a/src/pages/Mypage/Mypage.module.scss
+++ b/src/pages/Mypage/Mypage.module.scss
@@ -87,7 +87,7 @@
 .profileInput {
   @extend %inputStyle;
 
-  max-width: 36.6rem;
+  width: 36.6rem;
 
   @include media(tablet) {
     width: 100%;

--- a/src/pages/Mypage/index.tsx
+++ b/src/pages/Mypage/index.tsx
@@ -8,6 +8,7 @@ import httpClient from '@/src/apis/httpClient';
 import { initialUserInfo } from '@/src/types/mypageResponse';
 import addIcon from '@/src/assets/icons/addIcon.svg';
 import styles from './Mypage.module.scss';
+import { useRouter } from 'next/router';
 
 const Mypage: NextPageWithLayout = () => {
   const [userInfo, setUserInfo] = useState(initialUserInfo);
@@ -22,6 +23,8 @@ const Mypage: NextPageWithLayout = () => {
   const [isSaveButtonEnabled, setIsSaveButtonEnabled] = useState<boolean>(false);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [modalMessage, setModalMessage] = useState<string>('');
+
+  const router = useRouter();
 
   // userInfo 가져오기
   async function getUserInfo() {
@@ -150,6 +153,7 @@ const Mypage: NextPageWithLayout = () => {
   const handleModalClose = () => {
     setModalMessage('');
     setIsModalOpen(false);
+    router.reload();
   };
 
   return (


### PR DESCRIPTION
## 변경 사항
- 대시보드 수정 페이지(/Edit) 반응형 구현
- 계정관리 페이지(/Mypage) 반응형 수정
- InputComponent eyeIcon 수정

## To. reviewers
- @seolsis 원래는 눈이 떠있는데 비밀번호가 안 보이고, 눈이 감겨있는데 비밀번호가 보여서 아이콘 수정했어요 시연하다가 발견해가지고 제가 수정해서 올립니다 !!!!!!!!!!
## 수정 전
<img width="543" alt="스크린샷 2024-04-30 오전 4 40 44" src="https://github.com/thgus5335/DoThisDoThat/assets/155047307/18860165-dc7e-4869-8d25-3c5eaaaeb58e">
<img width="540" alt="스크린샷 2024-04-30 오전 4 40 51" src="https://github.com/thgus5335/DoThisDoThat/assets/155047307/a9907f04-40f0-4252-b4ec-393d4f37cbce">

## 수정 후
<img width="535" alt="스크린샷 2024-04-30 오전 4 42 01" src="https://github.com/thgus5335/DoThisDoThat/assets/155047307/65aa8cfa-c718-448b-9526-f427eab7bab1">
<img width="542" alt="스크린샷 2024-04-30 오전 4 42 06" src="https://github.com/thgus5335/DoThisDoThat/assets/155047307/528d8dc6-78dc-4bb2-ad38-bf96e8420a3d">

## 이슈 번호
- #53 

## (테스트 결과)
* 대시보드 수정 페이지(/Edit) 반응형
## 💻 PC
<img width="361" alt="스크린샷 2024-04-30 오전 5 09 19" src="https://github.com/thgus5335/DoThisDoThat/assets/155047307/b6202857-22ca-4cd3-b9b2-124d9bbe8660">

## 📉 Tablet
<img width="354" alt="스크린샷 2024-04-30 오전 5 09 02" src="https://github.com/thgus5335/DoThisDoThat/assets/155047307/0c4d195a-a2ef-4efc-85d2-e4775dc70a38">

## 📱 Mobile
<img width="345" alt="스크린샷 2024-04-30 오전 5 07 33" src="https://github.com/thgus5335/DoThisDoThat/assets/155047307/688f49a8-d62c-4cc1-bf3d-664cc5f2aab6">